### PR TITLE
Employment History and Change Position

### DIFF
--- a/DB/src/employee/employee.controller.js
+++ b/DB/src/employee/employee.controller.js
@@ -77,6 +77,7 @@ router.put('/employees/:empId/profile/manager', async (req, res) => {
   res.json(response);
 });
 
+// Gets the list of all reports an employee has been involved in
 router.get('/employees/:empId/profile/report-history', async (req, res) => {
   if (notLoggedIn(req, res)) return;
   
@@ -108,6 +109,29 @@ router.put('/employees/:empId/profile/report-history', async (req, res) => {
 
   let response = await model.createReport(connection, req.body, by_Employee);
   res.json(response);
-})
+});
+
+// Gets the employment history of an employee
+router.get('/employees/:empId/profile/employment-history', async (req, res) => {
+  if (notLoggedIn(req, res)) return;
+
+  let {connection, message} = await conn.getConnection(res);
+  if (message == 'fail') return;
+
+  let response = await model.getEmploymentHistory(connection, req.params.empId);
+  res.json(response);
+});
+
+// Sets an employee's position to be something else and adds a new record in
+// employment_history
+router.put('/employees/:empId/profile/change-position', async (req, res) => {
+  if (notLoggedIn(req, res)) return;
+
+  let {connection, message} = await conn.getConnection(res);
+  if (message == 'fail') return;
+
+  let response = await model.changePosition(connection, req.params.empId, req.body.position);
+  res.json(response);
+});
 
 module.exports = router;

--- a/DB/src/employee/employee.model.js
+++ b/DB/src/employee/employee.model.js
@@ -166,6 +166,40 @@ async function createReport(connection, {_for_emp_id, _report, _severity}, by_Em
   }
 }
 
+async function getEmploymentHistory(connection, empId) {
+  let rows;
+  try {
+    [rows] = await connection.query(`SELECT * FROM employment_history WHERE id = ?`, [empId]);
+  }
+  catch (err) {
+    logger.error(err.stack);
+    return {message: 'fail'};
+  }
+
+  return {message: 'succeed', history: rows};
+}
+
+async function changePosition(connection, empId, position) {
+  try {
+    await connection.query(`UPDATE employees SET pos = ? WHERE id = ?`, [position, empId]);
+
+    let today = new Date();
+    let dd = String(today.getDate()).padStart(2, '0');
+    let mm = String(today.getMonth() + 1).padStart(2, '0');
+    let yyyy = String(today.getFullYear());
+    let fullDate = `${mm}/${dd}/${yyyy}`;
+
+    await connection.query(`INSERT INTO employment_history SET ?`, 
+      {id: empId, position: position, start_date: fullDate});
+  }
+  catch (err) {
+    logger.error(err.stack);
+    return {message: 'fail'};
+  }
+
+  return {message: 'succeed'};
+}
+
 module.exports = {
   getEmployees,
   getEmployee,
@@ -175,5 +209,7 @@ module.exports = {
   setManager,
   reportHistory,
   addStrike,
-  createReport
+  createReport,
+  getEmploymentHistory,
+  changePosition
 };

--- a/DB/src/setup/dbsetup.sql
+++ b/DB/src/setup/dbsetup.sql
@@ -63,3 +63,11 @@ CREATE TABLE perf_reviews(
     primary key(id),
     foreign key (emp_id) references employees(id)
 );
+
+CREATE TABLE employment_history(
+    id int not null,
+    position varchar(50) not null,
+    start_date varchar(50) not null,
+    primary key (id, position),
+    foreign key (id) references employees(id)
+);

--- a/DB/src/setup/dbsetup.sql
+++ b/DB/src/setup/dbsetup.sql
@@ -68,6 +68,6 @@ CREATE TABLE employment_history(
     id int not null,
     position varchar(50) not null,
     start_date varchar(50) not null,
-    primary key (id, position),
+    primary key (id, position, start_date),
     foreign key (id) references employees(id)
 );

--- a/DB/src/setup/sampledata.sql
+++ b/DB/src/setup/sampledata.sql
@@ -11,3 +11,7 @@ INSERT INTO reports VALUES
 INSERT INTO perf_reviews (emp_id, review, score, creation_date, active) VALUES
     (2, 'this is a performance review', 3, "11/3/2019", 'true'),
     (2, 'this is also a performance review', 4, '10/3/2019', 'true');
+
+INSERT INTO employment_history VALUES
+    (1, "Software Engineer", "1/1/2007"),
+    (1, "Professor", "1/1/2012");


### PR DESCRIPTION
I added a table to the database called `employment_history`, and added two endpoints:

- `GET /employees/:empId/profile/employment-history`
This returns the employment history for a specific employee.

- `PUT /employees/:empId/profile/change-position`
This updates the current position of a specific employee as well as adds a new listing to the `employment_history` table.