### PR TITLE
Db perf reviews

### DIFF
--- a/DB/src/account/account.controller.js
+++ b/DB/src/account/account.controller.js
@@ -37,8 +37,10 @@ router.get('/login', async (req, res) => {
   if (message == 'fail') return;
 
   let response = await model.login(connection, req.body);
+  console.log(response)
   if (response.message == 'succeed') {
     req.session.active = true;
+    req.session.auth = response.id
     res.json(response);
   }
   else {

--- a/DB/src/account/account.model.js
+++ b/DB/src/account/account.model.js
@@ -47,7 +47,7 @@ async function login(connection, {username, password}) {
   
   hash = hashPassword(password, rows[0].salt);
   if (hash == rows[0].password) {
-    return {message: 'succeed'};
+    return {message: 'succeed', id: rows[0].id};
   }
   else {
     return {message: 'fail'};

--- a/DB/src/employee/employee.controller.js
+++ b/DB/src/employee/employee.controller.js
@@ -55,6 +55,18 @@ router.put('/employees/:empId/profile', async (req, res) => {
   res.json(response);
 });
 
+//Adds an employee to the database- must be logged in to do so
+router.post('/employees', async (req, res) => {
+  if (notLoggedIn(req, res)) return;
+
+  let {connection, message} = await conn.getConnection(res);
+  if (message == 'fail') return;
+
+  let response = await model.addEmployee(connection, req.body);
+
+  res.json(response);
+});
+
 // Remove employee from database
 router.delete('/employees/:empId', async (req, res) => {
   if (notLoggedIn(req, res)) return;

--- a/DB/src/employee/employee.model.js
+++ b/DB/src/employee/employee.model.js
@@ -26,6 +26,36 @@ async function getEmployees(connection) {
   return {message: 'succeed', employeeCount: empList.length, employees: empList};
 }
 
+async function addEmployee(connection, empDetails) {
+  //check if id already in the table
+  let rows;
+  try {
+    [rows] = await connection.query(`select * from employees where id = ${empDetails.id}`);
+  }
+  catch (e) {
+    if (e == undefined) logger.info('yes for some reason');
+    logger.error(e.stack);
+    return {message: 'fail'};
+  }
+    
+  if (rows[0] != undefined) {
+    return {message: 'employee id already exists'};
+  }
+  //(2, 'Marcus', 'Sykora', 1, 'Student', '1', 'address', 'email2', 214, 5, 0, null, null, null, 'true');
+  try {
+    await connection.query(`INSERT INTO employees VALUES (${empDetails.id}, '${empDetails.fname}', 
+    '${empDetails.lname}', ${empDetails.dep_id}, '${empDetails.pos}', 
+    '${empDetails.manager}', '${empDetails.addr}', '${empDetails.email}', 
+    ${empDetails.phn_num}, -1, ${empDetails.strikes}, null, null, null, 'true')`)
+  }
+  catch(e) {
+    logger.error(e);
+    return {message: 'fail'};
+  }
+
+  return {message: 'succeed'};
+}
+
 async function removeEmployee(connection, empId) {
   try {
     await connection.query(`update employees set active = 'false' where id = ${empId}`);
@@ -169,6 +199,7 @@ async function createReport(connection, {_for_emp_id, _report, _severity}, by_Em
 module.exports = {
   getEmployees,
   getEmployee,
+  addEmployee,
   removeEmployee,
   getContactInfo,
   updateContactInfo,

--- a/DB/src/perf_reviews/perf_reviews.controller.js
+++ b/DB/src/perf_reviews/perf_reviews.controller.js
@@ -31,7 +31,7 @@ router.post('/employees/:empId/profile/performance_reviews', async (req, res) =>
 router.get('/employees/:empId/profile/performance_reviews', async (req, res) => {
 
   if (notLoggedIn(req,res)) return;
-  console.log("id: req.session.auth")
+  console.log(req.session.auth)
   let {connection, message} = await conn.getConnection(res);
   if (message == 'fail') return;
 
@@ -51,7 +51,7 @@ router.delete('/employees/:empId/profile/performance_reviews/:perf_id', async (r
 })
 
 //allows a manager to see all performance reviews for any employee under him/her
-router.get('/employees/manager_perf_reviews', async (req,res) => {
+router.get('/employees/manager/perf_reviews', async (req,res) => {
   if (notLoggedIn(req,res)) return;
 
   let {connection, message} = await conn.getConnection(res);

--- a/DB/src/perf_reviews/perf_reviews.controller.js
+++ b/DB/src/perf_reviews/perf_reviews.controller.js
@@ -26,11 +26,16 @@ router.post('/employees/:empId/profile/performance_reviews', async (req, res) =>
 
 });
 
+//now gets only the employee that is currently logged in if it matches the one that is requested 
+//could also be amended if (or is manager) once we have that
 router.get('/employees/:empId/profile/performance_reviews', async (req, res) => {
+
+  if (notLoggedIn(req,res)) return;
+  console.log("id: req.session.auth")
   let {connection, message} = await conn.getConnection(res);
   if (message == 'fail') return;
 
-  let perf_rev = await model.seeAllPerfRevs(connection, req.params.empId);
+  let perf_rev = await model.seeAllPerfRevs(connection, req.params.empId, req.session.auth);
   res.json(perf_rev);
 });
 
@@ -43,6 +48,17 @@ router.delete('/employees/:empId/profile/performance_reviews/:perf_id', async (r
 
   let response = await model.deletePerfRev(connection, req.params.empId, req.params.perf_id);
   res.json(response);
+})
+
+//allows a manager to see all performance reviews for any employee under him/her
+router.get('/employees/manager_perf_reviews', async (req,res) => {
+  if (notLoggedIn(req,res)) return;
+
+  let {connection, message} = await conn.getConnection(res);
+  if (message == 'fail') return;
+
+  let manager_perf_rev = await model.seeAllPerfRevsManager(connection, req.session.auth);
+  res.json(manager_perf_rev);
 })
 
 

--- a/DB/src/perf_reviews/perf_reviews.model.js
+++ b/DB/src/perf_reviews/perf_reviews.model.js
@@ -53,6 +53,7 @@ async function deletePerfRev(connection, empId, perfRevId) {
 
 async function seeAllPerfRevsManager(connection, managerID) {
   let rows;
+  let revList = [];
   try {
     [rows] = await connection.query(`SELECT * FROM perf_reviews 
       INNER JOIN employees ON perf_reviews.emp_id = employees.id 
@@ -66,7 +67,9 @@ async function seeAllPerfRevsManager(connection, managerID) {
   for (var i in rows) {
     if (rows[i].manager == managerID) { 
     revList.push({
-      id:             rows[i].id, 
+      id:             rows[i].id,
+      fname:          rows[i].fname,
+      lname:          rows[i].lname, 
       emp_id:         rows[i].emp_id, 
       review:         rows[i].review,                   
       score:          rows[i].score, 

--- a/DB/src/perf_reviews/perf_reviews.model.js
+++ b/DB/src/perf_reviews/perf_reviews.model.js
@@ -14,7 +14,7 @@ async function postNewPerfRev(connection, empId, body) {
     return {message: 'succeed'};
   }
 
-async function seeAllPerfRevs(connection, empId) {
+async function seeAllPerfRevs(connection, empId, loggedInId) {
   try {
     [rows] = await connection.query(`SELECT * FROM perf_reviews WHERE (emp_id = ${empId} AND active = 'true') ORDER BY creation_date`);
   }
@@ -25,15 +25,18 @@ async function seeAllPerfRevs(connection, empId) {
   var revList = [];
   
   for (var i in rows) {
+    if (rows[i].emp_id == loggedInId) { 
     revList.push({
       id:             rows[i].id, 
       emp_id:         rows[i].emp_id, 
       review:         rows[i].review,                   
       score:          rows[i].score, 
       creation_date:  rows[i].creation_date,
-    });
+    })
   }
-  return {message: 'succeed', reviews: revList};
+  };
+  if (revList.length == 0) return {message: 'no performance reviews found for this profile, or you are not looking at your own profile'}
+  else return {message: 'succeed', reviews: revList};
 }
 
 async function deletePerfRev(connection, empId, perfRevId) {
@@ -48,10 +51,35 @@ async function deletePerfRev(connection, empId, perfRevId) {
   return {message: 'succeed'};
 }
 
-
+async function seeAllPerfRevsManager(connection, managerID) {
+  let rows;
+  try {
+    [rows] = await connection.query(`SELECT * FROM perf_reviews 
+      INNER JOIN employees ON perf_reviews.emp_id = employees.id 
+      WHERE employees.manager = 1
+      ORDER BY creation_date`)
+  }
+  catch (e) {
+    logger.error(e.stack);
+    return {message: 'fail'};
+  }
+  for (var i in rows) {
+    if (rows[i].manager == managerID) { 
+    revList.push({
+      id:             rows[i].id, 
+      emp_id:         rows[i].emp_id, 
+      review:         rows[i].review,                   
+      score:          rows[i].score, 
+      creation_date:  rows[i].creation_date,
+    })
+  }
+}
+return {message: 'succeed', reviews: revList};
+}
 module.exports = {
     //functions that will be used
     postNewPerfRev,
     seeAllPerfRevs,
-    deletePerfRev
+    deletePerfRev,
+    seeAllPerfRevsManager
   };

--- a/DB/src/setup/sampledata.sql
+++ b/DB/src/setup/sampledata.sql
@@ -10,4 +10,5 @@ INSERT INTO reports VALUES
 
 INSERT INTO perf_reviews (emp_id, review, score, creation_date, active) VALUES
     (2, 'this is a performance review', 3, "11/3/2019", 'true'),
-    (2, 'this is also a performance review', 4, '10/3/2019', 'true');
+    (2, 'this is also a performance review', 4, '10/3/2019', 'true'),
+    (1, 'this is a performance review', 3, "11/3/2019", 'true');


### PR DESCRIPTION
Functions completed:
`/employees/manager/perf_reviews/get`: Allows a manager to get all the perf reviews of anyone under him/her, grouped by each person that received it. Returns the following info for each review: "id," (of report) "fname," "lname," "emp_id" (of the involved one), "review," "score," and "creation_date."

amended `employees/:empID/profile/performance_reviews` to only work if the currently-logged employee has the same ID has "empID." Will give an error message that roughly says "either you are not the person that has empID, or there are no perf_reviews to show." Because of needing this info, I also changed the login to create a field called `req.session.auth` that stores the employee ID.

`employees/post` creates a new employee in the database, with a new rating of -1, null username/pw fields, and 'active' set to true. Checks to see if the ID already exists and returns a helpful error message if it is already found in the database.